### PR TITLE
Fix history save logic and optional imports

### DIFF
--- a/ephemerear/__init__.py
+++ b/ephemerear/__init__.py
@@ -1,2 +1,8 @@
+"""Convenience imports for the :mod:`ephemerear` package."""
+
 from .EphemerEar import *
-from .transcribe import * 
+from .transcribe import *
+
+# Provide access to the function helpers under a capitalised module name
+# for compatibility with existing code and tests.
+from . import functions as Functions

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,8 +1,13 @@
 import pytest
 import sys
-sys.path.append('/Users/donalphipps/Documents/aiphoria/EphemerEar')
+from pathlib import Path
 
-from ephemerear import Functions
+# Ensure the package root is on the path so that ``ephemerear`` can be imported
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+import ephemerear
+from ephemerear import functions as Functions
 
 @pytest.fixture
 def setup_todo_environment(tmp_path):
@@ -32,10 +37,7 @@ def test_add_todo_appends_to_file(setup_todo_environment):
 
 #### Testing `load_yaml_to_dict` Function
 
-from ephemerear import ephemerear
-
-import pytest
-from ephemerear.EphemerEar import EphemerEar 
+from ephemerear.EphemerEar import EphemerEar
 
 def test_load_yaml_to_dict_returns_correct_structure(tmp_path):
     yaml_content = """
@@ -57,15 +59,20 @@ def test_load_yaml_to_dict_returns_correct_structure(tmp_path):
     """
     yaml_file = tmp_path / "config.yaml"
     yaml_file.write_text(yaml_content)
-    exec = EphemerEar(str(yaml_file))
+    ee = EphemerEar(str(yaml_file))
     loaded_config = ee.load_yaml_to_dict(str(yaml_file))  # Pass the file path to the method
     assert loaded_config['bot']['name'] == "TestBot"
     assert loaded_config['bot']['model'] == "gpt-3.5-turbo"
     assert 'openai' in loaded_config['auth_tokens']
 
-def test_load_yaml_to_dict_raises_error_on_invalid_path():
+def test_load_yaml_to_dict_raises_error_on_invalid_path(tmp_path):
+    # Create a valid config file so that the EphemerEar instance initialises
+    yaml_content = "bot:\n  name: Test\n"
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text(yaml_content)
+    ee = EphemerEar(str(yaml_file))
     with pytest.raises(FileNotFoundError):
-         mb = ephemerear("invalid_path.yaml")
+        ee.load_yaml_to_dict("invalid_path.yaml")
         
 
 


### PR DESCRIPTION
## Summary
- expose `Functions` module in package init for compatibility
- handle optional dependencies by lazily importing `tiktoken`, `openai`, and `requests`
- fix `save_history` mutation bug
- clean up tests for path handling and config logic

## Testing
- `pytest -q` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_6847fa58db048324831e93c4e8eb17c9