### PR TITLE
Fix line breaks when writing transcripts

### DIFF
--- a/ephemerear/transcribe.py
+++ b/ephemerear/transcribe.py
@@ -105,8 +105,14 @@ def handle_transcript(transcript_text, transcript_output_dir, simplified_filenam
     transcript_filename = f"{simplified_filename}.md"
     transcript_path = os.path.join(transcript_output_dir, transcript_filename)
 
+    # Ensure that line breaks are respected when converting the markdown to
+    # other formats (e.g. ``docx``). ``pandoc`` and similar tools treat a single
+    # newline as a space, so we add two spaces before each newline to force a
+    # line break in the rendered output.
+    lines = transcript_text.splitlines()
     with open(transcript_path, 'w', encoding='utf-8') as transcript_file:
-        transcript_file.write(transcript_text)
+        for line in lines:
+            transcript_file.write(line.rstrip() + "  \n")
 
     print(f"Transcript written to {transcript_path}")
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -38,6 +38,7 @@ def test_add_todo_appends_to_file(setup_todo_environment):
 #### Testing `load_yaml_to_dict` Function
 
 from ephemerear.EphemerEar import EphemerEar
+from ephemerear.transcribe import handle_transcript
 
 def test_load_yaml_to_dict_returns_correct_structure(tmp_path):
     yaml_content = """
@@ -73,6 +74,16 @@ def test_load_yaml_to_dict_raises_error_on_invalid_path(tmp_path):
     ee = EphemerEar(str(yaml_file))
     with pytest.raises(FileNotFoundError):
         ee.load_yaml_to_dict("invalid_path.yaml")
+
+
+def test_handle_transcript_preserves_line_breaks(tmp_path):
+    transcript_dir = tmp_path
+    transcript_text = "00:00:00: SPEAKER_00: 'Hello'\n00:00:05: SPEAKER_01: 'Hi'"
+    simplified_filename = "sample"
+    handle_transcript(transcript_text, str(transcript_dir), simplified_filename, year_month_folders=False)
+    output_file = transcript_dir / f"{simplified_filename}.md"
+    content = output_file.read_text()
+    assert content == "00:00:00: SPEAKER_00: 'Hello'  \n00:00:05: SPEAKER_01: 'Hi'  \n"
         
 
 


### PR DESCRIPTION
## Summary
- add space-newline to ensure transcript line breaks convert to `docx`
- test `handle_transcript` writes break markers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_68484f6b55e88324bb2444ad4405de82