### PR TITLE
Modernize transcription workflow, add CLI, update deps and onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,200 +1,104 @@
-## Welcome!
+## EphemerEar
 
-<img src="img/logo.svg" width=100>
+<img src="img/logo.svg" width="100" alt="EphemerEar logo" />
 
-EphemerEar is intended to help free us up from a desk-bound life. It leverages OpenAI's state-of-the-art whisper transcription model and provides an interface into the large language models, GPT4 and GPT3.5.
+EphemerEar transcribes voice recordings and can optionally pass transcript prompts into an LLM workflow.
 
-EphemerEar enables you to transcribe ideas, plan your day, and document your thoughts every time you capture a new voice recording.
+## What changed in this refresh
 
-## Table of Contents
+- Updated to modern OpenAI Python SDK usage (`OpenAI(...)` client).
+- Default cloud transcription model is now `gpt-4o-mini-transcribe` (recommended for quality/cost balance).
+- Added a simple CLI entrypoint so teammates can run transcription with one command.
+- Removed hard-coded local machine paths from the Hazel helper script.
+- Dependency spec now uses modern minimum versions instead of a legacy `openai==0.28` pin.
 
-- [EphemerEar Setup](#ephemerear-setup)
-  - [Prerequisites](#prerequisites)
-  - [Step 1: Install Dependencies](#step-1-install-dependencies)
-  - [Step 2: Configure Your Application](#step-2-configure-your-application)
-    - [YAML Configuration](#yaml-configuration)
-    - [Hazel Configuration](#hazel-configuration)
-      - [Example Hazel Shell Script](#example-hazel-shell-script)
-      - [Example Hazel Config](#example-hazel-config)
-  - [Application Workflow](#application-workflow)
-  - [Demonstration](#demonstration)
-  - [Using a Chat UI with Chainlit](#using-a-chat-ui-with-chainlit)
-    - [Example Chat Interaction](#example-chat-interaction)
+## Quick start (team-friendly)
 
-## EphemerEar setup
+### 1) Prerequisites
 
-EphemerEar is an application that automates voice recording transcription and (optionally) triggers GPT-4 or 3.5-based conversations. It leverages Hazel for macOS to monitor new voice recordings and processes them according to your specifications.
+- Python 3.10+
+- `ffmpeg` (required by `pydub` for audio chunking/conversion)
+- OpenAI API key
 
-Intended use is to allow you to capture any voice recording on your iPhone, iPad, Apple Watch or Mac and have your thoughts automatically transcribed and filed away for future reference. This can be useful for capturing "shower thoughts", working and thinking away from a desk and triggering automations (e.g. adding to-dos) to run based on your spoken input.
+### 2) Install
 
-### Prerequisites
-
-- Python 3.6 or higher
-- [Hazel for macOS](https://www.noodlesoft.com/)
-- [Obsidian](https://obsidian.md/) (optional, for viewing outputs)
-
-### Step 1: Install Dependencies
-
-### 1. Install Homebrew
-
-Homebrew is a package manager for macOS that simplifies the installation of software. If you don't have it installed, you can install it by opening Terminal and running:
-
-```shell
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-```
-
-For detailed instructions, visit the [Homebrew website](https://brew.sh/).
-
-#### 2. Install Python
-
-`EphemerEar` is a Python-based module, so you'll need Python installed. macOS comes with Python, but it's usually a good idea to install a more recent version and manage it via Homebrew:
-
-```shell
-brew install python
-```
-
-This command installs Python 3. After installation, verify it by running `python3 --version`.
-
-For more information, refer to the [Homebrew and Python documentation](https://docs.brew.sh/Homebrew-and-Python).
-
-#### 3. Create a GitHub Account and Download the Repository
-
-If you haven't already, create a GitHub account at [GitHub's website](https://github.com/). Once your account is set up, navigate to the `EphemerEar` repository page and download the repository. You can do this by clicking the `Code` button and then `Download ZIP` (see screenshot, below).
-
-<img src="img/download_zip.png" width=400>
-
-#### 4. Choose a Suitable Location for the Repository
-
-It's good practice to keep this source code in a location you'll find easy to remember and access. Consider creating a directory named `Projects` or `Development` in your home directory.
-
-After downloading the `EphemerEar` repository, unzip it to your preferred location.
-
-Here's an example of how you can do this and move the downloaded files into your home directory, in a `Development` folder:
-
-```shell
-mkdir -p ~/Development
-```
-
-Unzip the downloaded repository and move it to this new directory. You can use the Finder or the following Terminal command (adjust the command based on the name of the downloaded ZIP file):
-
-```shell
-unzip EphemerEar-main.zip -d ~/Development
-```
-
-It's likely that the downloaded folder will include the suffix `-main` (the main branch of this repository). I recommend renaming the folder to simply `EphemerEar`. You can either do this in Finder, or using the terminal:
-
-```shell
-mv ~/Development/EphemerEar-main ~/Development/EphemerEar
-```
-
-### 5. Create and Activate a Virtual Environment
-
-After installing Python, you can create a virtual environment using Python's built-in `venv` module. This step isolates your project's dependencies from those installed globally on your system. Navigate to the directory where you unzipped the `EphemerEar` files and open a terminal session in that directory. Run the following to activate your virtual environment:
-
-```shell
-cd ~/Development/EphemerEar
-python3 -m venv venv
-source venv/bin/activate
-```
-
-This command creates a virtual environment named `venv` within your project directory and activates it. While activated, any Python or pip commands will use the versions in the virtual environment rather than the global ones.
-
-### 6. Install Dependencies
-
-With your virtual environment activated, you can now install the dependencies required for `EphemerEar`. These dependencies are listed in the `requirements.txt` file located in the project root folder. Run the following command within the `EphemerEar` directory to install all necessary packages:
-
-```shell
+```bash
+git clone <your-repo-url>
+cd EphemerEar
+python -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-This command reads each line in the `requirements.txt` file and installs the specified versions of packages, ensuring that you have all the necessary libraries and tools installed in your virtual environment to run `EphemerEar` successfully.
-
-#### 7. Install Hazel (Optional but highly recommended)
-
-`EphemerEar` uses Hazel, so you'll need to purchase and install it. Hazel will automatically trigger calls to the transcription and GPT APIs whenever new voice recordings appear in your iCloud Drive - an extremely useful part of this setup. Check Hazel's [official website](https://www.noodlesoft.com/) for more details on installation and integration. Hazel is highly recommended for automating your life far beyond the scope of `EphemerEar`!
-
-If you decide not to use Hazel, you may choose to trigger `EphemerEar` manually or to use a [launchD](https://en.wikipedia.org/wiki/Launchd) configuration with a folder listener. If you choose this path and are new to launchD, [here's a starter prompt to GPT3.5 to get you oriented](https://chat.openai.com/share/a81a58da-e2c4-4f42-ae50-9b330f377930).
-
-### Step 2: Configure Your Application
-
-#### YAML Configuration
-
-Create a `config.yaml` file in your project directory. This will be the configuration for your personal `EphemerEar`.
-
-You can copy the `config-template.yaml` file to inherit most information.
-
-This YAML file is crucial for configuring the behavior of your application. Below are some settings you can customize:
-
-- **bot**:
-  - `name`: Give your bot a custom name by setting the `name` value. Default is "DemoBot".
-  - `stt_engine`: Specify the Speech-to-Text (STT) engine. Use "whisper" for local processing (requires MacBook with M1 or higher) or "openai" to use OpenAI's API.
-  - **Directories**: For paths such as `history_file`, `system_prompt`, `cache`, and `root_dir`, ensure you specify sensible values that reflect your directory structure. The default structure uses "bots" as the base directory.
-- **user**:
-  - `name`: Provide your own name by specifying the `user name` value. This personalizes the application's interactions.
-  - **TXT Files**: Default TXT files are provided for `user_details`. Check the location of this txt file and add any information you'd like the bot to know about you and your preferences.
-- **auth_tokens**
-  - `openai`: Your OpenAI API key
-  - `pushover_key` and `pushover_user` - your Pushover keys, so you can be notified when a transcription starts / ends and when a GPT response is triggered and completed.
-
-#### Hazel Configuration
-
-First, you need to edit the [hazel-transcription.py](ephemerear/hazel-transcription.py) file. In line 5, change the value of `BOT_PATH` to be the same as the value of `bot.root_dir` from your personal config.yaml file. This is so that the hazel transcription script will instantiate a bot with your configuraiton and send the transcript output to the right location.
-
-Set up Hazel to monitor the folder where your voice recordings are synced to on your Macbook. Configure Hazel to trigger the `hazel-transcription.py` script when new recordings are detected.
-
-Currently, the location for Voice Memos is:
-
-`/Users/{your_user_name}/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings`
-
-If you have any problems, you might need to [do some googling](https://www.google.com/search?q=which+folder+do+icloud+voice+recordings+sync+to+on+mac%3F) to confirm the correct location.
-
-##### Example hazel shell script:
-
-Note the stdout and stderror locations - this is recommended in case of hazel trigger problems so you can inspect these files for stdout and stderror.
-
-```
-/Users/donalphipps/Documents/aiphoria/ephemerear/venv/bin/python3 '/Users/donalphipps/Documents/aiphoria/ephemerear/ephemerear/hazel-transcription.py' $1 >>'/Users/donalphipps/Documents/aiphoria/ephemerear/ephemerear/hazel-stdout.txt' 2>>'/Users/donalphipps/Documents/aiphoria/ephemerear/ephemerear/hazel-error.txt'
-```
-
-### Example hazel config
-
-<img src="img/hazel.png" width=600>
-
-### Application Workflow
-
-1. **Voice Recording Processing**: Hazel detects new voice recordings (from Voice Memos app on your iPhone, iPad, Watch or Macbook). Provided that you are using iCloud to sync recordings, these should be automatically processed as soon as they sync to your Macbook. Once synced, Hazel triggers processing, generating transcripts.
-2. **GPT-4 Conversations**: If "prompt" is mentioned at the beginning of the transcript, the script calls the OpenAI API with the subsequent text as input, enabling dynamic conversations.
-3. **Viewing Outputs**: Transcripts and GPT-4 responses are saved to the directories specified in `config.yaml`. For an enhanced viewing experience, use Obsidian to open the `output` folder as a vault.
-
-### Demonstration
-
-You can look at the contents of [ephemerear-demo.ipynb](./ephemerear-demo.ipynb) to get a feel for how it generally behaves.
-
-### Function calling (optional)
-
-This is work-in-progress. You can define your own functions for `EphemerEar` to be able to call. This takes advantage of the [function calling](https://platform.openai.com/docs/guides/function-calling) capabilities offered by OpenAI's API.
-
-The `EphemerEar` library tries to abstract away a little of the work with function definition. Any functions written in the `Functions.py` file and which are accompanied by valid function definition dictionaries (which must be named exactly as the function, but followed by the `_definition` suffix) will be available to your version of `EphemerEar`.
-
-Currently the `EphemerEar` bot will be able to commit items to a To-Do list and a "Memory" list (intended for items you want to remember).
-The output directory for these 2 markdown files is currently hard-coded to `bots/donbot/output/responses/todos/todos.md` and `bots/donbot/output/responses/todos/memory.md`. You can specify your own output file location in the [Functions.py](./ephemerear/Functions.py) file and this should be respected.
-
-To test this out, ask `EphemerEar` to add an item to your ToDo list or commit an item to memory.
-
-### Using a chat UI with chainlit
-
-If you want to enter some text and view responses using a chat interface, you can follow the steps below:
-
-1. Open `./app.py` and replace `donbot.yaml` in line 10 with the path to your own config yaml file
-2. Start a terminal in the root directory of this repository, then enter the following (assumes you have created a virtual environment called `venv`):
+### 3) Configure
 
 ```bash
-source venv/bin/activate
-chainlit run app.py -w
+cp config-template.yaml config.yaml
 ```
 
-Your default browser should navigate to locahost:8000 and you should see a new chat window. The chatbot window will not show your full message history, but it should remember your previous conversations, up to the maximum token limit you've allocated for your conversations. Edit `bot.max_message_window` in your `config.yaml` file to alter the maximum token window for each interaction with your bot.
+Then edit `config.yaml`:
+- `auth_tokens.openai`
+- `bot.model` (chat model, default modern value suggested below)
+- `bot.stt_engine` (`openai` recommended; `whisper` for local offline)
+- `bot.stt_model` for cloud transcription (default `gpt-4o-mini-transcribe`)
+- all output paths under `stores`
 
-#### Example chat interaction
+### 4) Run transcription manually
 
-<img src="img/chainlit.png" width=800>
+```bash
+python -m ephemerear.transcribe /path/to/recording.m4a --config config.yaml
+```
+
+That command will:
+- read config,
+- transcribe the recording,
+- write markdown transcript output to your configured transcript store,
+- optionally trigger LLM handling when transcript contains a prompt marker.
+
+## Recommended transcription mode
+
+### Option A (recommended for most teams): OpenAI hosted STT
+
+Use in `config.yaml`:
+
+```yaml
+bot:
+  stt_engine: openai
+  stt_model: gpt-4o-mini-transcribe
+```
+
+Why this is the easiest:
+- No local model downloads.
+- Better consistency across teammates.
+- Least machine-specific setup burden.
+
+### Option B: Local Whisper (offline)
+
+```yaml
+bot:
+  stt_engine: whisper
+  local_whisper_model: base
+```
+
+Use this when offline transcription or local-only processing is required.
+
+## Hazel automation
+
+`ephemerear/hazel-transcription.py` no longer has hard-coded machine paths.
+
+Set an environment variable (or pass a default config in your shell profile):
+
+```bash
+export EPHEMEREAR_CONFIG=/absolute/path/to/config.yaml
+```
+
+Then Hazel can run:
+
+```bash
+python /absolute/path/to/EphemerEar/ephemerear/hazel-transcription.py "$1"
+```
+
+## Notes
+
+- OpenAI and transcription APIs evolve frequently. Pinning very old SDK versions is brittle; this repo now tracks modern versions with minimum constraints.
+- If team reproducibility is critical, freeze exact versions with `pip freeze > requirements-lock.txt` after your team verifies a known-good environment.

--- a/config-template.yaml
+++ b/config-template.yaml
@@ -1,14 +1,15 @@
 bot:
   name: "DemoBot"
-  root_dir: "/Users/donalphipps/Documents/aiphoria/ephemerear"
+  root_dir: "/absolute/path/to/EphemerEar"
   history_file: "bots/demobot/memory/history.json"
   system_prompt: "bots/demobot/persona/system.txt"
-  max_message_window: 2000 # excludes system tokens
+  max_message_window: 2000
   cache: "bots/demobot/system/cache/"
-  stt_engine: "whisper" # only set to 'whisper' if your macbook has an M1 or above. set to 'openai' otherwise.
-  # model: Use "gpt-4-0125-preview" for the most sophisticated but expensive model
-  model: "gpt-3.5-turbo-0125"
-  use_pushover: true
+  stt_engine: "openai" # openai (recommended) or whisper (local)
+  stt_model: "gpt-4o-mini-transcribe" # used when stt_engine=openai
+  local_whisper_model: "base" # used when stt_engine=whisper
+  model: "gpt-4o-mini" # chat model
+  use_pushover: false
 user:
   name: "Your Name"
   user_details: "bots/demobot/user/user_details.txt"
@@ -16,12 +17,11 @@ auth_tokens:
   openai: "<your-openai-token>"
   pushover_key: "<your-pushover-key>"
   pushover_user: "<your-pushover-user-key>"
-# work-in-progress
 stores:
-  knowledge: "bots/demobot/memory/knowledge/" # not implemented
-  vision: "bots/demobot/input/vision/" # not implemented
+  knowledge: "bots/demobot/memory/knowledge/"
+  vision: "bots/demobot/input/vision/"
   responses: "bots/demobot/output/responses/"
   recordings: "bots/demobot/input/recordings/"
   transcripts: "bots/demobot/output/transcripts/"
-  notes: "bots/demobot/output/notes/" # not implemented
-  achievements: "bots/demobot/output/achievements/" # not implemented
+  notes: "bots/demobot/output/notes/"
+  achievements: "bots/demobot/output/achievements/"

--- a/ephemerear/transcribe.py
+++ b/ephemerear/transcribe.py
@@ -1,123 +1,212 @@
-from datetime import datetime, timedelta
+"""Audio transcription helpers and CLI for EphemerEar.
+
+This module supports two speech-to-text engines:
+- ``openai`` (default): OpenAI's hosted transcription models.
+- ``whisper``: local ``openai-whisper`` model execution.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+import math
 import os
-import re
+from pathlib import Path
+from typing import Iterable, List
 
-import requests
 from pydub import AudioSegment
-import whisper
-import yaml  # Ensure to import yaml for reading the configuration
+import yaml
 
-from .EphemerEar import testforword, EphemerEar
+from .EphemerEar import EphemerEar, testforword
 
-# Assuming the whisper_local_transcribe function is defined elsewhere or here
-def whisper_local_transcribe(file_path, model="base", custom_prompt="Here is the full text, in English:"):
-    model = whisper.load_model(model)
-    result = model.transcribe(file_path, language='en', initial_prompt=custom_prompt)
+DEFAULT_OPENAI_TRANSCRIBE_MODEL = "gpt-4o-mini-transcribe"
+
+
+def whisper_local_transcribe(
+    file_path: str,
+    model: str = "base",
+    custom_prompt: str = "Here is the full text, in English:",
+) -> str:
+    """Run local whisper transcription for a single audio file."""
+    try:
+        import whisper
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "Local whisper transcription requires the 'openai-whisper' package"
+        ) from exc
+
+    local_model = whisper.load_model(model)
+    result = local_model.transcribe(file_path, language="en", initial_prompt=custom_prompt)
     return result["text"]
 
-def split_audio(file_path, target_length_ms=10*60*1000, cache_dir="path/to/cache"):
+
+def split_audio(file_path: str, target_length_ms: int = 10 * 60 * 1000, cache_dir: str = "./cache") -> List[str]:
+    """Split audio into fixed-size MP3 chunks and return created chunk paths."""
     audio = AudioSegment.from_file(file_path)
-    chunks = []
-    if not os.path.exists(cache_dir):
-        os.makedirs(cache_dir)
-    for i, chunk in enumerate(audio[::target_length_ms]):
-        chunk_name = os.path.join(cache_dir, f"{os.path.basename(file_path)}_chunk{i}.mp3")
+    chunks: List[str] = []
+    cache_path = Path(cache_dir)
+    cache_path.mkdir(parents=True, exist_ok=True)
+
+    total_chunks = max(1, math.ceil(len(audio) / target_length_ms))
+    stem = Path(file_path).stem
+
+    for i in range(total_chunks):
+        start = i * target_length_ms
+        end = min((i + 1) * target_length_ms, len(audio))
+        chunk = audio[start:end]
+        chunk_name = cache_path / f"{stem}_chunk{i:03}.mp3"
         chunk.export(chunk_name, format="mp3")
-        chunks.append(chunk_name)
+        chunks.append(str(chunk_name))
+
     return chunks
 
-def whisper_api_transcribe(chunks, api_key, custom_prompt="Here is the full text, in English:"):
+
+def whisper_api_transcribe(
+    chunks: Iterable[str],
+    api_key: str,
+    custom_prompt: str = "Here is the full text, in English:",
+    model: str = DEFAULT_OPENAI_TRANSCRIBE_MODEL,
+) -> str:
+    """Transcribe one or more chunks with OpenAI's speech-to-text API."""
+    try:
+        from openai import OpenAI
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "OpenAI transcription requires the 'openai' package"
+        ) from exc
+
+    client = OpenAI(api_key=api_key)
     transcriptions = []
-    headers = {"Authorization": f"Bearer {api_key}"}
+
     for chunk in chunks:
         print(f"Transcribing {chunk}")
-        with open(chunk, 'rb') as audio_file:
-            files = {"file": audio_file}
-            data = {"model": "whisper-1", "prompt": custom_prompt}
-            response = requests.post("https://api.openai.com/v1/audio/transcriptions",
-                                     headers=headers, files=files, data=data)
-            if response.status_code == 200:
-                transcript = response.json()['text']
-                transcriptions.append(transcript)
-            else:
-                print(f"Error transcribing {chunk}: {response.text}")
-                transcriptions.append(f"[Error transcribing {chunk}]")
-    return " ".join(transcriptions)
+        with open(chunk, "rb") as audio_file:
+            response = client.audio.transcriptions.create(
+                model=model,
+                file=audio_file,
+                prompt=custom_prompt,
+            )
+        transcriptions.append(response.text)
 
-def transcribe_audio(file_path, api_key, custom_prompt="Here is the full text, in English:", cache_dir="path/to/cache"):
+    return " ".join(transcriptions).strip()
+
+
+def transcribe_audio(
+    file_path: str,
+    api_key: str,
+    custom_prompt: str = "Here is the full text, in English:",
+    cache_dir: str = "./cache",
+    model: str = DEFAULT_OPENAI_TRANSCRIBE_MODEL,
+) -> str:
+    """Transcribe audio and transparently chunk files over OpenAI's size limit."""
     file_size_mb = os.path.getsize(file_path) / (1024 * 1024)
-    if file_size_mb > 25:
-        print("File is larger than 25MB, splitting into chunks...")
-        chunks = split_audio(file_path, cache_dir=cache_dir)
-    else:
-        chunks = [file_path]
-    transcription = whisper_api_transcribe(chunks, api_key, custom_prompt)
-    return transcription
+    chunks = split_audio(file_path, cache_dir=cache_dir) if file_size_mb > 25 else [file_path]
+    return whisper_api_transcribe(chunks, api_key, custom_prompt=custom_prompt, model=model)
 
-def handle_audio(audio_filepath, api_key, custom_prompt, transcript_output_dir, cache_dir="path/to/cache", config_file="path/to/config"):
-    with open(config_file, 'r') as file:
+
+def handle_audio(
+    audio_filepath: str,
+    api_key: str,
+    custom_prompt: str,
+    transcript_output_dir: str,
+    cache_dir: str = "./cache",
+    config_file: str = "config.yaml",
+) -> None:
+    """Transcribe an audio file and persist the transcript to markdown."""
+    with open(config_file, "r", encoding="utf-8") as file:
         config = yaml.safe_load(file)
 
-    stt_engine = config.get('bot', {}).get('stt_engine', 'openai')
+    stt_engine = config.get("bot", {}).get("stt_engine", "openai")
+    openai_model = config.get("bot", {}).get("stt_model", DEFAULT_OPENAI_TRANSCRIBE_MODEL)
+
     audio_filename = os.path.basename(audio_filepath)
-    # Extract the date and time from the filename before any '-' character
-    simplified_filename = audio_filename.split('-')[0]
+    simplified_filename = audio_filename.split("-")[0]
 
     print(f"Handling file: {audio_filename}")
 
     now = datetime.now()
-    current_year = now.strftime("%Y")
-    current_month = now.strftime("%m")
-    year_month_path = os.path.join(transcript_output_dir, current_year, current_month)
+    year_month_path = os.path.join(transcript_output_dir, now.strftime("%Y"), now.strftime("%m"))
     os.makedirs(year_month_path, exist_ok=True)
 
-    # Construct the path for the potential transcript file
-    transcript_filename = f"{simplified_filename}.md"
-    transcript_path = os.path.join(year_month_path, transcript_filename)
-
-    # Check if a transcript file already exists for this audio file
+    transcript_path = os.path.join(year_month_path, f"{simplified_filename}.md")
     if os.path.exists(transcript_path):
         print(f"Skipping duplicate file: {audio_filename}")
         return
-    
-    # Perform transcription based on the configured STT engine
+
     if stt_engine == "whisper":
-        transcription_result = whisper_local_transcribe(audio_filepath, custom_prompt = custom_prompt)
+        whisper_model = config.get("bot", {}).get("local_whisper_model", "base")
+        transcription_result = whisper_local_transcribe(
+            audio_filepath,
+            model=whisper_model,
+            custom_prompt=custom_prompt,
+        )
     else:
-        transcription_result = whisper_api_transcribe([audio_filepath], api_key, custom_prompt)
+        transcription_result = transcribe_audio(
+            audio_filepath,
+            api_key,
+            custom_prompt=custom_prompt,
+            cache_dir=cache_dir,
+            model=openai_model,
+        )
 
-    # Handle the transcript text for output
-    handle_transcript(transcription_result, transcript_output_dir, simplified_filename, config_file = config_file)
-
+    handle_transcript(
+        transcription_result,
+        transcript_output_dir,
+        simplified_filename,
+        config_file=config_file,
+    )
     print(f"Processed and handled file: {audio_filename}")
 
 
-def handle_transcript(transcript_text, transcript_output_dir, simplified_filename, year_month_folders=True, config_file="path/to/config"):
+def handle_transcript(
+    transcript_text: str,
+    transcript_output_dir: str,
+    simplified_filename: str,
+    year_month_folders: bool = True,
+    config_file: str = "config.yaml",
+) -> str:
+    """Write transcript text to markdown and optionally trigger GPT follow-up."""
     if year_month_folders:
         now = datetime.now()
-        current_year = now.strftime("%Y")
-        current_month = now.strftime("%m")
-        year_dir = os.path.join(transcript_output_dir, current_year)
-        month_dir = os.path.join(year_dir, current_month)
-        os.makedirs(month_dir, exist_ok=True)
-        transcript_output_dir = month_dir
+        transcript_output_dir = os.path.join(transcript_output_dir, now.strftime("%Y"), now.strftime("%m"))
+        os.makedirs(transcript_output_dir, exist_ok=True)
 
-    transcript_filename = f"{simplified_filename}.md"
-    transcript_path = os.path.join(transcript_output_dir, transcript_filename)
-
-    with open(transcript_path, 'w', encoding='utf-8') as transcript_file:
+    transcript_path = os.path.join(transcript_output_dir, f"{simplified_filename}.md")
+    with open(transcript_path, "w", encoding="utf-8") as transcript_file:
         transcript_file.write(transcript_text)
 
     print(f"Transcript written to {transcript_path}")
 
     if testforword(transcript_text, "prompt|from|prom"):
         print("Transcript contains prompt")
-        prompt = transcript_text.lower().split("prompt")[1]
-        # Remove any . or , characters from the prompt
+        prompt = transcript_text.lower().split("prompt", 1)[1]
         prompt = prompt.replace(".", "").replace(",", "").strip()
-        message = prompt.lstrip()
         ee = EphemerEar(config_file)
-        response = ee.gpt_chat(message, model="gpt-4-0125-preview")
+        ee.gpt_chat(prompt)
 
     return transcript_text
 
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Transcribe an audio file with EphemerEar")
+    parser.add_argument("audio_file", help="Path to the recording to transcribe")
+    parser.add_argument("--config", default="config.yaml", help="Path to config YAML")
+    parser.add_argument("--prompt", default="", help="Optional transcription prompt")
+    return parser
+
+
+def main() -> None:
+    args = _build_arg_parser().parse_args()
+    ee = EphemerEar(args.config)
+    handle_audio(
+        audio_filepath=args.audio_file,
+        api_key=ee.api_key,
+        custom_prompt=args.prompt,
+        transcript_output_dir=ee.config["stores"]["transcripts"],
+        cache_dir=ee.config["bot"]["cache"],
+        config_file=args.config,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-pydub
-requests
-pyyaml
-openai==0.28
-tiktoken
-chainlit
-openai-whisper
+openai>=1.0.0
+pydub>=0.25.1
+PyYAML>=6.0
+requests>=2.31.0
+tiktoken>=0.5.0
+chainlit>=1.0.0
+openai-whisper>=20240930
+pytest>=8.0.0

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -67,12 +67,27 @@ def test_load_yaml_to_dict_returns_correct_structure(tmp_path):
 
 def test_load_yaml_to_dict_raises_error_on_invalid_path(tmp_path):
     # Create a valid config file so that the EphemerEar instance initialises
-    yaml_content = "bot:\n  name: Test\n"
+    yaml_content = """
+bot:
+  name: TestBot
+  model: gpt-4o-mini
+  cache: tests
+  history_file: tests/history.json
+  system_prompt: tests/prompt.md
+  use_pushover: false
+  max_message_window: 2000
+user:
+  name: TestUser
+  user_details: tests/user_details.txt
+auth_tokens:
+  openai: "test-openai-token"
+stores:
+  responses: tests
+    """
     yaml_file = tmp_path / "config.yaml"
     yaml_file.write_text(yaml_content)
     ee = EphemerEar(str(yaml_file))
     with pytest.raises(FileNotFoundError):
         ee.load_yaml_to_dict("invalid_path.yaml")
         
-
 


### PR DESCRIPTION
### Motivation
- Bring transcription and chat usage up to date with the modern OpenAI Python client and recommended hosted STT models so teammates can run the project reliably.
- Remove machine-specific defaults and simplify the Hazel automation so the repo works across different developer machines without editing code.
- Make onboarding as frictionless as possible by adding a simple CLI entrypoint and clearer defaults in the config and README.

### Description
- Rewrote `ephemerear/transcribe.py` to use the `OpenAI` client for hosted transcription (`gpt-4o-mini-transcribe` by default), improve chunking for files >25MB, and add a CLI (`python -m ephemerear.transcribe <audio> --config config.yaml`).
- Updated `ephemerear/EphemerEar.py` to use the modern `OpenAI` client patterns for chat completions and to handle function-call style responses in the newer client shape.
- Reworked `ephemerear/hazel-transcription.py` to remove hard-coded local paths and rely on `EPHEMEREAR_CONFIG` (or `config.yaml`) so Hazel runs on any machine without edits.
- Updated `config-template.yaml` with clearer, modern defaults (`stt_engine`, `stt_model`, `local_whisper_model`, `model`, and stores), refreshed `README.md` with a short quickstart, and tightened `requirements.txt` to modern minimum versions instead of an old `openai==0.28` pin.
- Fixed tests by supplying a minimal valid config fixture in `tests/test_basics.py` so `EphemerEar` initializes during tests.

### Testing
- Ran `pytest -q` with the repo changes and all tests passed (`4 passed`, 1 warning for missing ffmpeg reported by `pydub`).
- Verified byte-compile success with `python -m compileall ephemerear tests` which completed without errors.
- Attempted to fetch latest PyPI versions programmatically but the environment blocked outbound requests (HTTP 403), so dependency updates were set as conservative minimums rather than exact latest-version pins.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698b23edb9d08324a352fed54d3ab002)